### PR TITLE
Publish All in Network Node's RPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 # Environment files
 .env
 certbot/
+conf/rpc/letsencrypt/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 
 # direnv cache
 .direnv
+
+# Environment files
+.env
+certbot/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,7 @@ dependencies = [
  "pallet-balances",
  "pallet-grandpa",
  "pallet-marketplace-nfts",
+ "pallet-nicks",
  "pallet-proxy",
  "pallet-randomness-collective-flip",
  "pallet-rmrk-core",
@@ -4099,6 +4100,20 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-nicks"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
  "sp-io",
  "sp-runtime",
  "sp-std",

--- a/conf/rpc/crontab/crontab.conf
+++ b/conf/rpc/crontab/crontab.conf
@@ -1,0 +1,3 @@
+# m   h  dom  mon  dow   command
+  0   5   *    *    *    docker-compose -f /home/ubuntu/app/docker-compose.yaml up certbot
+  10  5   *    *    *    docker-compose -f /home/ubuntu/app/docker-compose.yaml exec nginx nginx -s reload

--- a/conf/rpc/nginx/templates-initiate/rpc.all-in.app.conf.template
+++ b/conf/rpc/nginx/templates-initiate/rpc.all-in.app.conf.template
@@ -1,0 +1,11 @@
+server {
+    listen [::]:80;
+    listen 80;
+
+    server_name $DOMAIN;
+
+    location ~/.well-known/acme-challenge {
+        allow all;
+        root /var/www/certbot;
+    }
+}

--- a/conf/rpc/nginx/templates/rpc.all-in.app.conf.template
+++ b/conf/rpc/nginx/templates/rpc.all-in.app.conf.template
@@ -1,0 +1,42 @@
+server {
+    listen [::]:80 ipv6only=on;
+    listen 80;
+
+    server_name $DOMAIN;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen [::]:443 ssl http2 ipv6only=on;
+    listen 443 ssl http2;
+
+    server_name $DOMAIN;
+
+    ssl_certificate /etc/letsencrypt/live/$DOMAIN/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;
+
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location ~/.well-known/acme-challenge {
+        allow all;
+        root /var/www/html;
+        index index.html;
+    }
+
+    location / {
+        resolver 127.0.0.11 valid=30s;
+        set $parachain_node parachain-node:9944;
+
+        proxy_buffering off;
+        proxy_pass http://$parachain_node;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}

--- a/docker-compose-initiate.yml
+++ b/docker-compose-initiate.yml
@@ -1,0 +1,26 @@
+version: "3.8"
+
+services:
+  nginx:
+    container_name: nginx
+    image: nginx:latest
+    environment:
+      - DOMAIN
+    ports:
+      - 80:80
+    volumes:
+      - ./conf/rpc/nginx/templates-initiate:/etc/nginx/templates
+      - ./conf/rpc/letsencrypt:/etc/letsencrypt
+      - ./certbot/data:/var/www/certbot
+  certbot:
+    container_name: certbot
+    image: certbot/certbot:latest
+    depends_on:
+      - nginx
+    command: >-
+              certonly --reinstall --webroot --webroot-path=/var/www/certbot
+              --email ${EMAIL} --agree-tos --no-eff-email
+              -d ${DOMAIN}
+    volumes:
+      - ./conf/rpc/letsencrypt:/etc/letsencrypt
+      - ./certbot/data:/var/www/certbot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,6 @@ services:
       - CARGO_HOME=/var/www/parachain-node/.cargo
     volumes:
       - .:/var/www/parachain-node
-      - type: bind
-        source: ./.local
-        target: /root/.local
     command: bash -c "cargo build --release && ./target/release/all-in-network --dev --ws-external"
   rpc:
     container_name: rpc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,44 @@
-version: "3.2"
+version: "3.8"
 
 services:
-  dev:
-    container_name: node-template
+  parachain-node:
+    container_name: parachain-node
     image: paritytech/ci-linux:production
-    working_dir: /var/www/node-template
+    working_dir: /var/www/parachain-node
     ports:
       - "9944:9944"
     environment:
-      - CARGO_HOME=/var/www/node-template/.cargo
+      - CARGO_HOME=/var/www/parachain-node/.cargo
     volumes:
-      - .:/var/www/node-template
+      - .:/var/www/parachain-node
       - type: bind
         source: ./.local
         target: /root/.local
-    command: bash -c "cargo build --release && ./target/release/node-template --dev --ws-external"
+    command: bash -c "cargo build --release && ./target/release/all-in-network --dev --ws-external"
+  rpc:
+    container_name: rpc
+    image: nginx:latest
+    restart: unless-stopped
+    environment:
+      - DOMAIN
+    depends_on:
+      - parachain-node
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ./conf/rpc/nginx/templates:/etc/nginx/templates:ro
+      - ./conf/rpc/letsencrypt:/etc/letsencrypt:ro
+      - ./certbot/data:/var/www/certbot
+  certbot:
+    container_name: certbot
+    image: certbot/certbot:latest
+    depends_on:
+      - rpc
+    command: >-
+              certonly --reinstall --webroot --webroot-path=/var/www/certbot
+              --email ${EMAIL} --agree-tos --no-eff-email
+              -d ${DOMAIN}
+    volumes:
+      - ./conf/rpc/letsencrypt:/etc/letsencrypt
+      - ./certbot/data:/var/www/certbot

--- a/scripts/docker_run.sh
+++ b/scripts/docker_run.sh
@@ -2,9 +2,40 @@
 # This script is meant to be run on Unix/Linux based systems
 set -e
 
-echo "*** Start Substrate node template ***"
+echo "*** Starting All in Network node ***"
 
-cd $(dirname ${BASH_SOURCE[0]})/..
+# Evaluate current directory
+# ...
 
-docker-compose down --remove-orphans
-docker-compose run --rm --service-ports dev $@
+
+# Takes three parameters to associate with the certificate:
+#
+# - Application name
+# - Domain name
+# - Email
+#
+
+COMPOSE_PROJECT_NAME=$1
+DOMAIN=$2
+EMAIL=$3
+
+
+# Description
+echo COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} > .env
+echo DOMAIN=${DOMAIN} >> .env
+echo EMAIL=${EMAIL} >> .env
+
+
+# Phase 1
+docker compose -f ./docker-compose-initiate.yml up -d nginx
+docker compose -f ./docker-compose-initiate.yml up certbot
+docker compose -f ./docker-compose-initiate.yml down
+
+# some configurations for let's encrypt
+curl -L --create-dirs -o conf/rpc/letsencrypt/options-ssl-nginx.conf https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf
+
+openssl dhparam -out conf/rpc/letsencrypt/ssl-dhparams.pem 2048
+
+# Phase 2
+crontab ./conf/rpc/crontab/crontab.conf
+docker compose -f ./docker-compose.yml up -d

--- a/scripts/docker_run.sh
+++ b/scripts/docker_run.sh
@@ -1,29 +1,47 @@
 #!/usr/bin/env bash
 # This script is meant to be run on Unix/Linux based systems
+
 set -e
 
+
+# Check the current directory to ensure the user
+# executes the script successfully.
+if [ ! -d "scripts" ]; then
+  echo "You need to run this script from the project root folder."
+  exit 1
+fi
+
+
+# Load variables from env vars file, if currently defined
+if [ -f ".env" ]; then
+  export $(cat .env | xargs)
+fi
+
+
+# Check if the environment file is correctly defined
+if [ ! -f ".env" ] || \
+  [[ -z "${COMPOSE_PROJECT_NAME}" ]] || \
+  [[ -z "${DOMAIN}" ]] || \
+  [[ -z "${EMAIL}" ]]; then
+  echo "Complete the following information to deploy the node:"
+
+  # Get two parameters to associate with the
+  # RPC Let's Encrypt certificate.
+  #
+  # - Domain name
+  # - Domain email address
+  #
+  read -p "[RPC Domain Name]: " DOMAIN
+  read -p "[RPC Domain Email Address]: " EMAIL
+
+  # Export the parameters values to the project environment file
+  echo COMPOSE_PROJECT_NAME="all-in-app" > .env
+  echo DOMAIN=${DOMAIN} >> .env
+  echo EMAIL=${EMAIL} >> .env
+fi
+
+
 echo "*** Starting All in Network node ***"
-
-# Evaluate current directory
-# ...
-
-
-# Takes three parameters to associate with the certificate:
-#
-# - Application name
-# - Domain name
-# - Email
-#
-
-COMPOSE_PROJECT_NAME=$1
-DOMAIN=$2
-EMAIL=$3
-
-
-# Description
-echo COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} > .env
-echo DOMAIN=${DOMAIN} >> .env
-echo EMAIL=${EMAIL} >> .env
 
 
 # Phase 1

--- a/scripts/docker_run.sh
+++ b/scripts/docker_run.sh
@@ -44,7 +44,10 @@ fi
 echo "*** Starting All in Network node ***"
 
 
-# Phase 1
+# Remove old infrastructure
+docker compose down -v --remove-orphans
+
+# Prepare RPC Let's Encrypt certificate
 docker compose -f ./docker-compose-initiate.yml up -d nginx
 docker compose -f ./docker-compose-initiate.yml up certbot
 docker compose -f ./docker-compose-initiate.yml down
@@ -54,6 +57,8 @@ curl -L --create-dirs -o conf/rpc/letsencrypt/options-ssl-nginx.conf https://raw
 
 openssl dhparam -out conf/rpc/letsencrypt/ssl-dhparams.pem 2048
 
-# Phase 2
+# Define a cron job to renew the Let's Encrypt certificate
 crontab ./conf/rpc/crontab/crontab.conf
+
+# Deploy the new infrastructure
 docker compose -f ./docker-compose.yml up -d


### PR DESCRIPTION
## What?

This PR contains the required changes to publish All in Network RPC on Internet (https://rpc.all-in.app).

## Why?

This feature is important to connect All in Network user interface with the blockchain.

## How?

- Creating a Docker compose environment to get the RPC Let's Encrypt certificate.
- Creating a Docker compose environment to publish All in Network RPC on Internet.
- Creating a cron job to automatically renew RPC's Let's Encrypt certificate.
- Creating a bash script to deploy the infrastructure.